### PR TITLE
Add method to create new dask clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,5 @@ Released on ????? ?th, 20??.
 
 ### Added
 
-- `task_name` task - [#1](https://github.com/giorgiobasile/prefect-planetary-computer/pull/1)
+- Added Planetary Computer credentials block and Dask Gateway client - [#7](https://github.com/giorgiobasile/prefect-planetary-computer/pull/7)
+- Added method to programmatically instatiate new Dask clusters - [#8](https://github.com/giorgiobasile/prefect-planetary-computer/pull/8)

--- a/prefect_planetary_computer/credentials.py
+++ b/prefect_planetary_computer/credentials.py
@@ -10,18 +10,11 @@ from prefect.blocks.core import Block
 from pydantic import Field, SecretStr
 
 CATALOG_URL = "https://planetarycomputer.microsoft.com/api/stac/v1/"
+
 GATEWAY_ADDRESS = (
     "https://pccompute.westeurope.cloudapp.azure.com/compute/services/dask-gateway"
 )
 GATEWAY_PROXY_ADDRESS = "gateway://pccompute-dask.westeurope.cloudapp.azure.com:80"
-CLUSTER_IMAGES_BASE = "mcr.microsoft.com/planetary-computer/"
-CLUSTER_DEFAULT_ENV = {
-    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
-    "GDAL_HTTP_MERGE_CONSECUTIVE_RANGES": "YES",
-    "GDAL_HTTP_MAX_RETRY": "5",
-    "GDAL_HTTP_RETRY_DELAY": "3",
-    "USE_PYGEOS": "0",
-}
 
 
 class PlanetaryComputerCredentials(Block):
@@ -56,10 +49,56 @@ class PlanetaryComputerCredentials(Block):
         title="JupyterHub API Token",
     )
 
+    def get_stac_catalog(self, **pystac_kwargs) -> pystac_client.Client:
+        """
+        Provides a PySTAC client for the PC data catalog, automatically signing items as they are retrieved.
+        For more information about PC signing, refer to the [docs](https://planetarycomputer.microsoft.com/docs/concepts/sas).
+
+        Args:
+            pystac_kwargs: Additional keyword arguments to pass to the [pystac_client.Client.open](https://pystac-client.readthedocs.io/en/stable/api.html#pystac_client.Client.open) method.
+
+        Returns:
+            A PySTAC client for the PC Catalog.
+
+        Example:
+            Get a configured PySTAC client with automatic asset signing:
+            ```python
+            from prefect import flow
+            from prefect_planetary_computer import PlanetaryComputerCredentials
+
+            @flow
+            def example_get_stac_catalog_flow():
+                pc_credentials_block = PlanetaryComputerCredentials.load("BLOCK_NAME")
+
+                catalog = pc_credentials_block.get_stac_catalog()
+
+                # Search STAC catalog for Landsat Collection 2 Level 2 items
+                time_range = "2020-12-01/2020-12-31"
+                bbox = [-122.2751, 47.5469, -121.9613, 47.7458]
+
+                search = catalog.search(collections=["landsat-c2-l2"], bbox=bbox, datetime=time_range)
+                items = search.get_all_items()
+                return len(items)
+
+            example_get_stac_catalog_flow()
+            ```
+        """  # noqa E501
+
+        if self.subscription_key:
+            planetary_computer.set_subscription_key(
+                self.subscription_key.get_secret_value()
+            )
+
+        return pystac_client.Client.open(
+            CATALOG_URL, modifier=planetary_computer.sign_inplace, **pystac_kwargs
+        )
+
     def get_dask_gateway(self, **gateway_kwargs) -> dask_gateway.Gateway:
         """
         Provides a client for the PC Dask Gateway Server,
         setting the proper addresses and Jupyter authentication.
+
+        For examples on how to use the Dask Gateway client, refer to the [PC - Scale with Dask](https://planetarycomputer.microsoft.com/docs/quickstarts/scale-with-dask/) tutorial.
 
         Args:
             gateway_kwargs: Additional keyword arguments to pass
@@ -96,51 +135,79 @@ class PlanetaryComputerCredentials(Block):
             address=GATEWAY_ADDRESS,
             proxy_address=GATEWAY_PROXY_ADDRESS,
             auth=JupyterHubAuth(api_token=self.hub_api_token.get_secret_value()),
-            **gateway_kwargs
+            **gateway_kwargs,
         )
 
-    def get_stac_catalog(self, **pystac_kwargs) -> pystac_client.Client:
+    def new_dask_gateway_cluster(
+        self,
+        worker_cores: Optional[float] = None,
+        worker_memory: Optional[float] = None,
+        image: Optional[str] = None,
+        gpu: Optional[bool] = False,
+        environment: Optional[dict] = None,
+        **gateway_cluster_kwargs,
+    ) -> dask_gateway.GatewayCluster:
         """
-        Provides a PySTAC client for the PC data catalog, automatically signing items as they are retrieved.
-        For more information about PC signing, refer to the [docs](https://planetarycomputer.microsoft.com/docs/concepts/sas).
+        Instantiate a new cluster from the PC Dask Gateway Server.
+
+        Please make sure to **share the same python dependencies** as the Docker image used for the Dask workers,
+        [as explained in the Dask docs](https://docs.dask.org/en/stable/how-to/manage-environments.html#manage-environments).
+
+        Each argument corresponds to one of the available PC Dask Gateway cluster option.
+        PC sets some defaults, but they can be overridden by passing the corresponding argument to this function -
+        [see Helm chart](https://github.com/microsoft/planetary-computer-hub/blob/main/helm/chart/config.yaml).
 
         Args:
-            pystac_kwargs: Additional keyword arguments to pass to the [pystac_client.Client.open](https://pystac-client.readthedocs.io/en/stable/api.html#pystac_client.Client.open) method.
+            worker_cores: Number of cores per worker, in the 0.1-8 range. Defaults to 1.
+            worker_memory: Amount of memory per worker (in GiB) in the 1-64 range. Defaults to 8.
+            image: The Docker image to be used for the workers. Defaults to [pangeo/pangeo-notebook:latest](https://hub.docker.com/layers/pangeo/pangeo-notebook/latest/images/sha256-94e97e24adf14e72c01f18c782b8c4e0efb1e05950a5f2d2e86e67adcbf547f8)
+                To use the PC official images, refer to the [planetary-computer-containers](https://github.com/Microsoft/planetary-computer-containers) repo.
+            gpu: Whether to use GPU workers. Defaults to False.
+            environment: Environment variables to set on the workers. Defaults to the GDAL and PYGEOS-related variables set in the PC Hub.
+            gateway_cluster_kwargs: Additional keyword arguments to pass to [`dask_gateway.GatewayCluster`](https://gateway.dask.org/api-client.html#dask_gateway.GatewayCluster) constructor.
 
         Returns:
-            A PySTAC client for the PC Catalog.
+            A client for the Dask cluster just created.
 
         Example:
-            Get a configured PySTAC client with automatic asset signing:
+            Instantiate a new cluster using PC Dask Gateway Server:
             ```python
+            import dask.array as da
             from prefect import flow
             from prefect_planetary_computer import PlanetaryComputerCredentials
 
             @flow
-            def example_get_stac_catalog_flow():
-                pc_credentials_block = PlanetaryComputerCredentials(
-                    subscription_key = "sub-key",
-                    hub_api_token = "hub-token"
-                )
-                catalog = pc_credentials_block.get_stac_catalog()
+            def example_new_dask_gateway_cluster_flow():
+                pc_credentials_block = PlanetaryComputerCredentials.load("BLOCK_NAME")
 
-                # Search STAC catalog for Landsat Collection 2 Level 2 items
-                time_range = "2020-12-01/2020-12-31"
-                bbox = [-122.2751, 47.5469, -121.9613, 47.7458]
+                # Create a Dask Gateway cluster with default configuration
+                # it will be automatically used for any subsequent dask compute
+                cluster = pc_credentials_block.new_dask_gateway_cluster()
 
-                search = catalog.search(collections=["landsat-c2-l2"], bbox=bbox, datetime=time_range)
-                items = search.get_all_items()
-                return len(items)
+                # Scale the cluster to at most 10 workers
+                cluster.adapt(minimum=2, maximum=10)
 
-            example_get_stac_catalog_flow()
+                # Create a Dask array with 1 billion elements and sum them
+                x = da.random.random(1000000000)
+                result = x.sum().compute()
+
+                return result
+
+            example_new_dask_gateway_cluster_flow()
             ```
         """  # noqa E501
 
-        if self.subscription_key:
-            planetary_computer.set_subscription_key(
-                self.subscription_key.get_secret_value()
-            )
+        gateway = self.get_dask_gateway(**gateway_cluster_kwargs)
 
-        return pystac_client.Client.open(
-            CATALOG_URL, modifier=planetary_computer.sign_inplace, **pystac_kwargs
-        )
+        if worker_cores is not None:
+            gateway_cluster_kwargs["worker_cores"] = worker_cores
+        if worker_memory is not None:
+            gateway_cluster_kwargs["worker_memory"] = worker_memory
+        if image is not None:
+            gateway_cluster_kwargs["image"] = image
+        if gpu is not None:
+            gateway_cluster_kwargs["gpu"] = gpu
+        if environment is not None:
+            gateway_cluster_kwargs["environment"] = environment
+
+        return gateway.new_cluster(**gateway_cluster_kwargs)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,11 +1,25 @@
-from dask_gateway import Gateway
+from dask_gateway import Gateway, GatewayCluster
 from pystac_client import Client
+
+from prefect_planetary_computer.credentials import GATEWAY_ADDRESS
 
 
 def test_get_dask_gateway(pc_credentials_block):
     gateway_client = pc_credentials_block.get_dask_gateway()
     assert isinstance(gateway_client, Gateway)
-    assert gateway_client.address == "127.0.0.1"
+    assert gateway_client.address == GATEWAY_ADDRESS
+
+
+def test_new_dask_gateway_cluster(pc_credentials_block):
+    gateway_cluster = pc_credentials_block.new_dask_gateway_cluster(
+        worker_cores=1.0,
+        worker_memory=8.0,
+        image="pangeo/pangeo-notebook:latest",
+        gpu=False,
+        environment={"GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR"},
+    )
+    assert isinstance(gateway_cluster, GatewayCluster)
+    assert gateway_cluster.name == "test-cluster"
 
 
 def test_get_stac_catalog(pc_credentials_block):


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
Provides a method to instantiate Dask clusters using the Hub token credential.

Closes #9 

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

```python
pc_credentials_block = PlanetaryComputerCredentials(
    subscription_key = "sub-key",
    hub_api_token = "hub-token"
)

# Create a Dask Gateway cluster with default configuration
# it will be automatically used for any subsequent dask compute
cluster = pc_credentials_block.new_dask_gateway_cluster()

# Scale the cluster to at most 10 workers
cluster.adapt(minimum=2, maximum=10)

# Create a Dask array with 1 billion elements and sum them
x = da.random.random(1000000000)
result = x.sum().compute()
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/giorgiobasile/prefect-planetary-computer/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/giorgiobasile/prefect-planetary-computer/blob/main/CHANGELOG.md)
